### PR TITLE
Fix incorrect syntax in udev

### DIFF
--- a/utils/99-mbm.rules
+++ b/utils/99-mbm.rules
@@ -9,7 +9,7 @@ SUBSYSTEMS=="usb", ATTRS{bInterfaceNumber}=="?*", ENV{.MBM_USBIFNUM}="$attr{bInt
 
 ATTRS{idVendor}=="413c", ATTRS{idProduct}=="8147|8183|8184|818d", ENV{.MBM_USBIFNUM}=="09", ENV{MBM_CAPABILITY}="gps_nmea"
 ATTRS{idVendor}=="0930", ATTRS{idProduct}=="130b|130c|1311", ENV{.MBM_USBIFNUM}=="09", ENV{MBM_CAPABILITY}="gps_nmea"
-ATTRS{idVendor}=="0bdb", ATTRS{idProduct}=="1900|1902|1904|1905|1906|1907|1911|190d", ENV{.MBM_USBIFNUM}=="09", ENV{MBM_CAPABILITY}="gps_nmea", {ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="0bdb", ATTRS{idProduct}=="1900|1902|1904|1905|1906|1907|1911|190d", ENV{.MBM_USBIFNUM}=="09", ENV{MBM_CAPABILITY}="gps_nmea", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 ATTRS{idVendor}=="413c", ATTRS{idProduct}=="8147|8183|8184|818d", ENV{.MBM_USBIFNUM}=="03", ENV{MBM_CAPABILITY}="gps_ctrl"
 ATTRS{idVendor}=="0930", ATTRS{idProduct}=="130b|130c|1311", ENV{.MBM_USBIFNUM}=="03", ENV{MBM_CAPABILITY}="gps_ctrl"


### PR DESCRIPTION
Added missing ENV{}

Signed-off-by: Olivier Mehani shtrom@ssji.net
